### PR TITLE
Feat/delete existing experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from utils import (
     get_experience_by_index, get_education_by_index,
     get_skill_by_index, update_experience_by_index,
     validate_request, delete_education_by_index,
-    update_education_by_index
+    update_education_by_index, delete_exp_by_index
 )
 app = Flask(__name__)
 SERVER_ERROR = "Server Error"
@@ -51,7 +51,7 @@ def hello_world():
     return jsonify({"message": "Hello, World!"})
 
 
-@app.route('/resume/experience', methods=['GET', 'POST', 'PUT'])
+@app.route('/resume/experience', methods=['GET', 'POST', 'PUT', 'DELETE'])
 def experience():
     '''
     Handles requests for experience. Determines what kind of request method 
@@ -67,6 +67,9 @@ def experience():
 
     if request.method == 'PUT':
         return handle_put_experience()
+
+    if request.method == 'DELETE':
+        return handle_delete_experience()
 
     return jsonify({"Server Error": "Couldn't process method"})
 
@@ -128,6 +131,16 @@ def handle_put_experience():
         return update_experience_by_index(data, index, req)
 
     return jsonify({"Server Error": "Couldn't process method"})
+
+def handle_delete_experience():
+    '''
+    Handle experience delete requests
+    '''
+    index = request.args.get("index")
+    if index is not None:
+        return delete_exp_by_index(data, index)
+
+    return jsonify({"Server Error": "Couldn't process method with no index"})
 
 @app.route('/resume/education', methods=['GET', 'POST', 'DELETE', 'PUT'])
 def education():

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -328,6 +328,12 @@ def test_exp_delete():
     item_id = app.test_client().post('/resume/experience',
                                      json=example_experience).json['id']
 
+    initial_get_response = app.test_client().get('/resume/experience')
+
     response = app.test_client().delete(f'/resume/experience?index={item_id}')
+
+    final_get_response = app.test_client().get('/resume/experience')
+
     assert response.status_code == 200
     assert response.json == example_experience
+    assert initial_get_response.json != final_get_response.json

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -309,3 +309,25 @@ def test_edu_update():
                                   json=updated_example_education)
     response = app.test_client().get('/resume/education')
     assert response.json[item_id] == updated_example_education
+
+def test_exp_delete():
+    '''
+    Delete an experience and then get all experiences. 
+    
+    Check that it deletes the experience at index 0 in that list
+    '''
+    example_experience = {
+        "title": "Software Developer",
+        "company": "A Cool Company",
+        "start_date": "October 2022",
+        "end_date": "Present",
+        "description": "Writing Python Code",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience',
+                                     json=example_experience).json['id']
+
+    response = app.test_client().delete(f'/resume/experience?index={item_id}')
+    assert response.status_code == 200
+    assert response.json == example_experience

--- a/utils.py
+++ b/utils.py
@@ -125,3 +125,19 @@ def update_experience_by_index(data, index, new_experience_json):
                 setattr(data["experience"][index], field, new_experience_json[field])
         return jsonify(data["experience"][index])
     return jsonify({"Server Error": "Couldn't find needed experience"})
+
+def delete_exp_by_index(data, index):
+    '''
+    Delete and return specific experience by index or None if not found
+    '''
+    index = int(index)
+    if 0 <= index < len(data["experience"]):
+        exp = data["experience"].pop(index)
+        return jsonify({"title": exp.title,
+                        "company": exp.company,
+                        "start_date": exp.start_date,
+                        "end_date": exp.end_date,
+                        "description": exp.description,
+                        "logo": exp.logo,
+                        })
+    return jsonify({"Server Error": "Couldn't find needed experience"})


### PR DESCRIPTION
Description:
This pull request aims to resolve the issue https://github.com/MLH-Fellowship/orientation-project-python-23.SUM.A/issues/5, which involves deleting existing experience. To achieve this, the pull request implements a DELETE request for the /resume/experience route using its index position as an identification parameter.

Key Changes:
- Implemented a DELETE request for the /resume/experience route.
- Added functionality to delete existing experience entries using the index position as an ID.

Benefits:
- Users can easily remove unwanted or outdated experience entries from their resume.
- Provides a straightforward and intuitive method for managing experience entries within the application.
- Enhances the overall user experience by allowing precise control over the resume content.

Testing:
- Conducted comprehensive unit tests to ensure the correct functioning of the DELETE request.
- Verified that the targeted experience entry is successfully deleted while preserving the integrity of other resume data.