### PR TITLE
Feat/add chatgpt reword

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Once you add your API key below, make sure to not share it with anyone! The API key should remain private.
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pytest_cache/
 __pycache__
 .vscode
+.env

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Make a copy of the example environment variables file:
+
+   ```bash
+   $ cp .env.example .env
+   ```
+
+Add your [API key](https://beta.openai.com/account/api-keys) to the newly created `.env` file.
+
 ## Run
 ```
 flask run

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flask
 pytest
 pylint
 Flask-Cors
+openai
+python-dotenv==0.19.2

--- a/utils.py
+++ b/utils.py
@@ -139,3 +139,22 @@ def update_skill_by_index(data, index, updated):
                         "logo": updated.logo,
                         })
     return jsonify({"Server Error": "Couldn't find needed skill"})
+
+def generate_description(keyphrases):
+    '''
+    Generate a description from the keyphrases
+    '''
+    return f"""Write job experience description.
+
+Keyphrases: Wrote python code. worked on flask. wrote unit tests
+Description: 
+- Developed Python code and utilized the Flask framework for building robust web applications.\n\n
+- Wrote comprehensive unit tests to validate the functionality and integrity of the code.\n\n
+- Collaborated with the team to identify and implement efficient solutions, ensuring seamless user experiences.\n\n
+- Ensured adherence to coding standards and best practices, resulting in high-quality and maintainable code.\n\n
+- Actively participated in code reviews, providing valuable feedback and incorporating improvements as necessary.\n\n
+Keyphrases: writing python code.
+Description: 
+- Developed Python scripts and applications for a wide range of projects, utilizing object-oriented principles and best practices.\n\n
+Keyphrases: {keyphrases.capitalize()}
+Description:"""


### PR DESCRIPTION
Description:
This pull request addresses https://github.com/MLH-Fellowship/orientation-project-python-23.SUM.A/issues/10 - Add ChatGPT functionality to help users reword the description section of their resume. It aims to reword the description key of the experience section, and create a more professional look of the resume

Key Changes:
2 new functions have been added. 1 in utils.py focused on the generated description, and the format required for emulation. The other in app.py, which focuses on the implementation of the generated description and handles the call 

Benefits:
Users would not have to worry about having to order and properly word the description section of their job experience. by just inputing key phrases, it is generated for them

Testing:
No test cases covered because there's no mock api to use, and the only way would be to expose my OpenAI API Key